### PR TITLE
Replace the view of new page in index page using turbo frame

### DIFF
--- a/app/views/blog_posts/index.html.erb
+++ b/app/views/blog_posts/index.html.erb
@@ -3,10 +3,13 @@
     <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
   <% end %>
 
-  <div class="flex justify-between items-center">
-    <h1 class="font-bold text-4xl">Blog posts</h1>
-    <%= link_to "New blog post", new_blog_post_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
-  </div>
+  <%# Replace this frame with a frame having the same id %>
+  <%= turbo_frame_tag "create-new-blog-post" do %>
+    <div class="flex justify-between items-center">
+      <h1 class="font-bold text-4xl">Blog posts</h1>
+      <%= link_to "New blog post", new_blog_post_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
+    </div>
+  <% end %>
 
   <div id="blog_posts" class="min-w-full">
     <%= render @blog_posts %>

--- a/app/views/blog_posts/new.html.erb
+++ b/app/views/blog_posts/new.html.erb
@@ -1,7 +1,9 @@
 <div class="mx-auto md:w-2/3 w-full">
   <h1 class="font-bold text-4xl">New blog post</h1>
 
-  <%= render "form", blog_post: @blog_post %>
-
-  <%= link_to "Back to blog posts", blog_posts_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+  <%# This frame will be replaced with the frame having this id %>
+  <%= turbo_frame_tag "create-new-blog-post" do %>
+    <%= render "form", blog_post: @blog_post %>
+    <%= link_to "Back to blog posts", blog_posts_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+  <%end%>
 </div>


### PR DESCRIPTION
<img width="1388" alt="SCR-20240430-pjdu" src="https://github.com/som-matrix/blog-post-hotwired/assets/69161480/3b7bc91e-c0ec-4b52-adf4-fccd4f4d43e3">

- When we click `New` instead of going to /blog_posts/new which does a full page reload , we just render the view of new page in index page itself without full page reload
- Clicking `Back` will render the index view again in the same page.

![SCR-20240430-pjfw](https://github.com/som-matrix/blog-post-hotwired/assets/69161480/54718120-068c-4956-9b4d-5057483d439d)
