### PR TITLE
Use the power of turbo stream

### DIFF
--- a/app/controllers/blog_posts_controller.rb
+++ b/app/controllers/blog_posts_controller.rb
@@ -25,11 +25,12 @@ class BlogPostsController < ApplicationController
 
     respond_to do |format|
       if @blog_post.save
-        format.html { redirect_to blog_post_url(@blog_post), notice: "Blog post was successfully created." }
-        format.json { render :show, status: :created, location: @blog_post }
+        # when a blog post is created, we prepend blog_post partial to the list of blog posts
+        format.turbo_stream { render turbo_stream: turbo_stream.prepend("blog_posts", 
+                              partial: "blog_post", locals: { blog_post: @blog_post },  
+                            )}
       else
         format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: @blog_post.errors, status: :unprocessable_entity }
       end
     end
   end

--- a/app/views/blog_posts/index.html.erb
+++ b/app/views/blog_posts/index.html.erb
@@ -11,6 +11,7 @@
     </div>
   <% end %>
 
+  <%# This conatiner will be used by turbo stream to prepend the newly created blog post %>
   <div id="blog_posts" class="min-w-full">
     <%= render @blog_posts %>
   </div>


### PR DESCRIPTION
<img width="1362" alt="SCR-20240430-pwrr" src="https://github.com/som-matrix/blog-post-hotwired/assets/69161480/468131b2-d5a4-4ac3-b588-eb3a027c4e4a">

- We click `New` and we see that the `index` view is getting replaced with the view of `new` because of `turbo_frame`
and the other part is remaining as it because it is not wrapped with turbo frame.
- Now we will fill the fields and click `Create`

<img width="1392" alt="SCR-20240430-pxgw" src="https://github.com/som-matrix/blog-post-hotwired/assets/69161480/6d9a22d6-8a89-4eb5-bcd7-15a1992e2daf">

- We are seeing that , without any page reload it is appending the new blog post to the list just like a SPA.
- This is because we are using `tubro_stream.prepend` method to add the partial of `blog_post` item inside the list of all blog posts container having the id of `blog_posts`.

<img width="1404" alt="SCR-20240430-pxnr" src="https://github.com/som-matrix/blog-post-hotwired/assets/69161480/f95cb5a2-5de3-49ec-bbcc-db1c8c9e6819">
