### PR TITLE
Implement turbo stream `remove` action 

### DIFF
--- a/app/controllers/blog_posts_controller.rb
+++ b/app/controllers/blog_posts_controller.rb
@@ -3,7 +3,7 @@ class BlogPostsController < ApplicationController
 
   # GET /blog_posts or /blog_posts.json
   def index
-    @blog_posts = BlogPost.all
+    @blog_posts = BlogPost.all.order(id: :desc)
   end
 
   # GET /blog_posts/1 or /blog_posts/1.json
@@ -26,8 +26,8 @@ class BlogPostsController < ApplicationController
     respond_to do |format|
       if @blog_post.save
         # when a blog post is created, we prepend blog_post partial to the list of blog posts
-        format.turbo_stream { render turbo_stream: turbo_stream.prepend("blog_posts", 
-                              partial: "blog_post", locals: { blog_post: @blog_post },  
+        format.turbo_stream { render turbo_stream: turbo_stream.prepend("blog_posts",
+                              partial: "blog_post", locals: { blog_post: @blog_post },
                             )}
       else
         format.html { render :new, status: :unprocessable_entity }
@@ -51,7 +51,7 @@ class BlogPostsController < ApplicationController
     @blog_post.destroy!
 
     respond_to do |format|
-      format.html { redirect_to blog_posts_url, notice: "Blog post was successfully destroyed." }
+      format.turbo_stream { render turbo_stream: turbo_stream.remove(@blog_post) }
     end
   end
 

--- a/app/views/blog_posts/_form.html.erb
+++ b/app/views/blog_posts/_form.html.erb
@@ -2,7 +2,6 @@
   <% if blog_post.errors.any? %>
     <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
       <h2><%= pluralize(blog_post.errors.count, "error") %> prohibited this blog_post from being saved:</h2>
-
       <ul>
         <% blog_post.errors.each do |error| %>
           <li><%= error.full_message %></li>
@@ -10,17 +9,14 @@
       </ul>
     </div>
   <% end %>
-
   <div class="my-5">
     <%= form.label :author %>
     <%= form.text_field :author, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
   </div>
-
   <div class="my-5">
     <%= form.label :content %>
     <%= form.text_area :content, rows: 4, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
   </div>
-
   <div class="inline">
     <%= form.submit class: "rounded-lg py-3 px-5 bg-blue-600 text-white inline-block font-medium cursor-pointer" %>
   </div>

--- a/app/views/blog_posts/index.html.erb
+++ b/app/views/blog_posts/index.html.erb
@@ -2,15 +2,13 @@
   <% if notice.present? %>
     <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
   <% end %>
-
   <%# Replace this frame with a frame having the same id %>
   <%= turbo_frame_tag "create-new-blog-post" do %>
-    <div class="flex justify-between items-center">
+    <div class="flex justify-between items-center" >
       <h1 class="font-bold text-4xl">Blog posts</h1>
       <%= link_to "New blog post", new_blog_post_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
     </div>
   <% end %>
-
   <%# This conatiner will be used by turbo stream to prepend the newly created blog post %>
   <div id="blog_posts" class="min-w-full">
     <%= render @blog_posts %>


### PR DESCRIPTION
# Issue
- When respond format is html in the destroy action results in causing a page refresh in result the current scroll position is also removed.

# Changes
- Add turbo stream respond format and use the `remove` action to remove the current blog_post and also preserve the scroll position automatically 

- Let's say with default html format i want to perform a destroy action for the below blog_post 

<img width="1493" alt="image" src="https://github.com/som-matrix/blog-post-hotwired/assets/69161480/3878ba85-46a5-4ab1-b032-8f671bfe15fb">

- If you see here now when we click Delete , it scrolled to the top 

<img width="1444" alt="image" src="https://github.com/som-matrix/blog-post-hotwired/assets/69161480/2e782842-8cd6-4d39-9d67-45f25f6b8cd5">

- With `turbo_stream.remove` action , we can see we are preserving the scroll position .

![image](https://github.com/som-matrix/blog-post-hotwired/assets/69161480/cf1eddf4-28f4-4200-ae54-8e715b47c11b)

<img width="1419" alt="image" src="https://github.com/som-matrix/blog-post-hotwired/assets/69161480/79e7d1e6-3dd9-40f2-a55c-de5558d717ce">
