### PR TITLE
Sprinkle stimulus to add client side form validation 

### DIFF
--- a/app/javascript/controllers/blog_form_controller.js
+++ b/app/javascript/controllers/blog_form_controller.js
@@ -1,0 +1,48 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = [
+    "authorName",
+    "blogContent",
+    "authorBlank",
+    "authorLimitExceeded",
+    "authorSpecialChar",
+    "contentBlank",
+  ];
+  connect() {
+    console.log("connected...");
+  }
+
+  handleChange() {
+    const authorName = this.authorNameTarget.value;
+    const blogContent = this.blogContentTarget.value;
+
+    // Blank author name
+    if (!authorName.length) {
+      this.authorBlankTarget.classList.remove("hidden");
+    } else {
+      this.authorBlankTarget.classList.add("hidden");
+    }
+
+    // Limit exceeds for author name
+    if (authorName.length > 10) {
+      this.authorLimitExceededTarget.classList.remove("hidden");
+    } else {
+      this.authorLimitExceededTarget.classList.add("hidden");
+    }
+
+    // No special characters
+    if (authorName.match(/[^\w\s]/)) {
+      this.authorSpecialCharTarget.classList.remove("hidden");
+    } else {
+      this.authorSpecialCharTarget.classList.add("hidden");
+    }
+
+    // Blank content
+    if (!blogContent.length) {
+      this.contentBlankTarget.classList.remove("hidden");
+    } else {
+      this.contentBlankTarget.classList.add("hidden");
+    }
+  }
+}

--- a/app/views/blog_posts/_form.html.erb
+++ b/app/views/blog_posts/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: blog_post, class: "contents") do |form| %>
+<%= form_with(model: blog_post, class: "contents", data: {controller: "blog-form"}) do |form| %>
   <% if blog_post.errors.any? %>
     <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
       <h2><%= pluralize(blog_post.errors.count, "error") %> prohibited this blog_post from being saved:</h2>
@@ -9,13 +9,29 @@
       </ul>
     </div>
   <% end %>
-  <div class="my-5">
+  <div class="my-5" >
     <%= form.label :author %>
-    <%= form.text_field :author, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+    <%= form.text_field :author, data: {action: "input->blog-form#handleChange", blog_form_target: "authorName"}, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+    <div class="flex flex-col gap-2">
+      <span class="text-red-500 hidden" data-blog-form-target="authorBlank">
+        Author name can't be blank
+      </span>
+      <span class="text-red-500 hidden" data-blog-form-target="authorLimitExceeded">
+        Author name can't exceed more than 10 characters
+      </span>
+      <span class="text-red-500 hidden" data-blog-form-target="authorSpecialChar">
+        Author name should not have any special characters
+      </span>
+    </div>
   </div>
   <div class="my-5">
     <%= form.label :content %>
-    <%= form.text_area :content, rows: 4, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+    <%= form.text_area :content, data: {action: "input->blog-form#handleChange", blog_form_target: "blogContent"}, rows: 4, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+    <div class="flex flex-col gap-2">
+      <span class="text-red-500 hidden" data-blog-form-target="contentBlank">
+        Content can't be blank
+      </span>
+    </div>
   </div>
   <div class="inline">
     <%= form.submit class: "rounded-lg py-3 px-5 bg-blue-600 text-white inline-block font-medium cursor-pointer" %>


### PR DESCRIPTION
# Issue
- Form validation in client side is missing 

# Changes
- Introduce hotwire stimulus in action
- Use stimulus concepts to add form validations on the input fields.

# Screenshots

<img width="1355" alt="SCR-20240502-nqsh" src="https://github.com/som-matrix/blog-post-hotwired/assets/69161480/db519e6a-8aa7-4f48-bb1f-359ffb496c9b">
<img width="1367" alt="SCR-20240502-nqua" src="https://github.com/som-matrix/blog-post-hotwired/assets/69161480/d77d32d7-9190-4534-b91b-1459e799d326">
<img width="1417" alt="SCR-20240502-nqwo" src="https://github.com/som-matrix/blog-post-hotwired/assets/69161480/7a5708d3-09c1-4487-aaa8-6bfa41d78d9e">
<img width="1350" alt="SCR-20240502-nqzj" src="https://github.com/som-matrix/blog-post-hotwired/assets/69161480/acb46ca2-2013-4c24-8a42-98323aa3cd45">
