### PR TITLE
Improve create and destroy action

### DIFF
--- a/app/controllers/blog_posts_controller.rb
+++ b/app/controllers/blog_posts_controller.rb
@@ -25,10 +25,13 @@ class BlogPostsController < ApplicationController
 
     respond_to do |format|
       if @blog_post.save
-        # when a blog post is created, we prepend blog_post partial to the list of blog posts
-        format.turbo_stream { render turbo_stream: turbo_stream.prepend("blog_posts",
-                              partial: "blog_post", locals: { blog_post: @blog_post },
-                            )}
+          format.turbo_stream do
+              render turbo_stream: [
+                turbo_stream.prepend("blog_posts", partial: "blog_post", locals: { blog_post: @blog_post }),
+                turbo_stream.remove("create-new-blog-post"),
+                turbo_stream.before("blog_posts", partial: "blog_posts_header")
+              ]
+          end
       else
         format.html { render :new, status: :unprocessable_entity }
       end

--- a/app/views/blog_posts/_blog_post.html.erb
+++ b/app/views/blog_posts/_blog_post.html.erb
@@ -1,4 +1,4 @@
-<div id="<%= dom_id blog_post %>" class="flex justify-between items-center" >
+<div id="<%= dom_id blog_post %>" >
   <%= turbo_frame_tag dom_id(blog_post) do %>
     <p class="my-5">
       <strong class="block font-medium mb-1">Author:</strong>
@@ -9,8 +9,9 @@
       <%= blog_post.content %>
     </p>
     <%= link_to "Edit", edit_blog_post_path(blog_post), class: "rounded-lg py-3 ml-2 px-5 bg-gray-100 inline-block font-medium" %>
+    <div class="inline-block ml-2">
+      <%= button_to "Delete", blog_post_path(blog_post), method: :delete, class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 font-medium" %>
+    </div>
+    <hr class="mt-6">
   <% end %>
-  <div class="inline-block ml-2">
-    <%= button_to "Delete", blog_post_path(blog_post), method: :delete, class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 font-medium" %>
-  </div>
 </div>

--- a/app/views/blog_posts/_blog_posts_header.html.erb
+++ b/app/views/blog_posts/_blog_posts_header.html.erb
@@ -1,0 +1,4 @@
+<div class="flex justify-between items-center" >
+  <h1 class="font-bold text-4xl">Blog posts</h1>
+  <%= link_to "New blog post", new_blog_post_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
+</div>

--- a/app/views/blog_posts/index.html.erb
+++ b/app/views/blog_posts/index.html.erb
@@ -4,10 +4,7 @@
   <% end %>
   <%# Replace this frame with a frame having the same id %>
   <%= turbo_frame_tag "create-new-blog-post" do %>
-    <div class="flex justify-between items-center" >
-      <h1 class="font-bold text-4xl">Blog posts</h1>
-      <%= link_to "New blog post", new_blog_post_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
-    </div>
+    <%= render "blog_posts_header" %>
   <% end %>
   <%# This conatiner will be used by turbo stream to prepend the newly created blog post %>
   <div id="blog_posts" class="min-w-full">


### PR DESCRIPTION
# Issue
- When a blog post is created the item is prepended but the form is still visible

# Changes
- Update create action to handle series of `turbo_stream` actions.
- Move the `Delete` button inside the `turbo_frame` as we are now handling the `turbo_stream` format in `destroy` action.